### PR TITLE
Integer fix and compression

### DIFF
--- a/moseq2_extract/cli.py
+++ b/moseq2_extract/cli.py
@@ -278,7 +278,6 @@ def extract(input_file, crop_size, bg_roi_dilate, bg_roi_shape, bg_roi_index, bg
             if use_tracking_model:
                 results['mask_frames'][results['depth_frames'] < min_height] = tracking_model_ll_clip
                 results['mask_frames'][results['mask_frames'] < tracking_model_ll_clip] = tracking_model_ll_clip
-                results['mask_frames'] = np.around(results['mask_frames'], 3)
                 tracking_init_mean = results['parameters']['mean'][-(offset+1)]
                 tracking_init_cov = results['parameters']['cov'][-(offset+1)]
 


### PR DESCRIPTION
Changed hdf5 storage of frames from int8 to uint8.  Now clipping log-likelihoods from the mouse tracker for better compression.