### PR TITLE
Added some code for sorting  ROIs

### DIFF
--- a/moseq2_extract/cli.py
+++ b/moseq2_extract/cli.py
@@ -44,13 +44,16 @@ def cli():
 @click.option('--bg-roi-gradient-threshold', default=3000, type=float, help='Gradient must be < this to include points')
 @click.option('--bg-roi-gradient-kernel', default=7, type=int, help='Kernel size for Sobel gradient filtering')
 @click.option('--bg-roi-fill-holes', default=True, type=bool, help='Fill holes in ROI')
+@click.option('--bg-sort-roi-by-position', default=False, type=bool, help='Sort ROIs by position')
+@click.option('--bg-sort-roi-by-position-max-rois', default=2, type=int, help='Max original ROIs to sort by position')
 @click.option('--output-dir', default=None, help='Output directory')
 @click.option('--use-plane-bground', default=False, type=bool, help='Use plane fit for background')
 @click.option("--config-file", type=click.Path())
 def find_roi(input_file, bg_roi_dilate, bg_roi_shape, bg_roi_index, bg_roi_weights, bg_roi_depth_range,
              bg_roi_gradient_filter, bg_roi_gradient_threshold, bg_roi_gradient_kernel, bg_roi_fill_holes,
+             bg_sort_roi_by_position, bg_sort_roi_by_position_max_rois,
              output_dir, use_plane_bground, config_file):
-    
+
     # set up the output directory
 
     if type(bg_roi_index) is int:
@@ -86,18 +89,9 @@ def find_roi(input_file, bg_roi_dilate, bg_roi_shape, bg_roi_index, bg_roi_weigh
                                   gradient_kernel=bg_roi_gradient_kernel,
                                   fill_holes=bg_roi_fill_holes)
 
-    #####
-    max_number_of_rois = 2
-    sort_rois_by_position = True
-    
-    if max_number_of_rois > 0:
-        rois = rois[:max_number_of_rois]
-
-    if sort_rois_by_position:
-        rois = [rois[i] for i in np.argsort([np.nonzero(roi)[0].mean() for roi in rois])]    
-    
-    #####
-
+    if bg_sort_roi_by_position:
+        rois = rois[:bg_sort_roi_by_position_max_rois]
+        rois = [rois[i] for i in np.argsort([np.nonzero(roi)[0].mean() for roi in rois])]
 
     bg_roi_index = [idx for idx in bg_roi_index if idx in range(len(rois))]
     for idx in bg_roi_index:


### PR DESCRIPTION
This pull request is meant to address a problem that comes up when there are multiple real ROIs in the recording that have a similar size. Basically, the problem is that because the ROI finding is stochastic, there are fluctuations in the ranking of ROIs determined by the system of weights and features. Thus, even if one runs the extract pipeline twice with two different indexes specified, the same ROI could be returned in both cases because it might happen to be at the idx-location in each run of the pipeline [this happened in my case quite frequently]. 

I tried to address this by adding another weighted feature for sorting the ROIs, which was the y-axis-position of the centroid. But this is not robust, since when the weight is too low, the ROIs fail to sort, and when it is too high, then bullshit ROIs that are near the top of the screen start to top the list. 

So you will see below the final solution I implemented, which requires the user to specify the expected number N of ROIs, after which the top N ROIs are sorted by y-axis position of their centroid. I didn't fold these options into the CLI scheme since I didn't want to fuck up the naming aesthetics but should be pretty straightforward. 