### PR TITLE
H5 result format hotfix

### DIFF
--- a/moseq2_extract/util.py
+++ b/moseq2_extract/util.py
@@ -196,18 +196,18 @@ def save_dict_contents_to_h5(h5, dic, root='/', annotations=None):
         elif isinstance(item, (int, float)):
             h5[dest] = np.asarray([item])[0]
         elif item is None:
-            h5[dest] = h5py.Empty(dtype='V')
+            h5.create_dataset(dest, data=h5py.Empty(dtype=h5py.special_dtype(vlen=str)))
         elif isinstance(item, dict):
             save_dict_contents_to_h5(h5, item, dest)
         else:
             raise ValueError('Cannot save {} type to key {}'.format(type(item), dest))
 
-        if key in annotations 
+        if key in annotations:
             if annotations[key] is None:
-                h5[dest].attrs['description'] = h5py.Empty(dtype='U')
+                h5[dest].attrs['description'] = ""
             else:
                 h5[dest].attrs['description'] = annotations[key]
-        
+
 
 def click_param_annot(click_cmd):
     """ Given a click.Command instance, return a dict that maps option names to help strings


### PR DESCRIPTION
I just discovered a bug originating from the `H5 result format` branch that exposed itself when running the extract command with a config file.  Problem is that there is no help string for this `click.Option`, so adding the description attribute to the dataset that contains the parameter value fails because h5py cannot handle `None` types directly. I see the following exception: 
```
Traceback (most recent call last):
  File "C:\Users\user\AppData\Local\Continuum\anaconda3\envs\moseq2\Scripts\moseq2-extract-script.py", line 11, in <module>
    load_entry_point('moseq2-extract', 'console_scripts', 'moseq2-extract')()
  File "C:\Users\user\AppData\Local\Continuum\anaconda3\envs\moseq2\lib\site-packages\click\core.py", line 764, in __call__
    return self.main(*args, **kwargs)
  File "C:\Users\user\AppData\Local\Continuum\anaconda3\envs\moseq2\lib\site-packages\click\core.py", line 717, in main
    rv = self.invoke(ctx)
  File "C:\Users\user\AppData\Local\Continuum\anaconda3\envs\moseq2\lib\site-packages\click\core.py", line 1137, in invoke
    return _process_result(sub_ctx.command.invoke(sub_ctx))
  File "c:\users\user\documents\python_repos\moseq2-extract-0.1.3\moseq2_extract\util.py", line 43, in invoke
    return super().invoke(ctx)
  File "C:\Users\user\AppData\Local\Continuum\anaconda3\envs\moseq2\lib\site-packages\click\core.py", line 956, in invoke
    return ctx.invoke(self.callback, **ctx.params)
  File "C:\Users\user\AppData\Local\Continuum\anaconda3\envs\moseq2\lib\site-packages\click\core.py", line 555, in invoke
    return callback(*args, **kwargs)
  File "c:\users\user\documents\python_repos\moseq2-extract-0.1.3\moseq2_extract\cli.py", line 320, in extract
    save_dict_contents_to_h5(f, status_dict['parameters'], 'metadata/extraction/parameters', click_param_annot(extract))
  File "c:\users\user\documents\python_repos\moseq2-extract-0.1.3\moseq2_extract\util.py", line 206, in save_dict_contents_to_h5
    h5[dest].attrs['description'] = annotations[key]
  File "h5py\_objects.pyx", line 54, in h5py._objects.with_phil.wrapper
  File "h5py\_objects.pyx", line 55, in h5py._objects.with_phil.wrapper
  File "C:\Users\user\AppData\Local\Continuum\anaconda3\envs\moseq2\lib\site-packages\h5py\_hl\attrs.py", line 95, in __setitem__
    self.create(name, data=value, dtype=base.guess_dtype(value))
  File "C:\Users\user\AppData\Local\Continuum\anaconda3\envs\moseq2\lib\site-packages\h5py\_hl\attrs.py", line 177, in create
    htype = h5t.py_create(original_dtype, logical=True)
  File "h5py\h5t.pyx", line 1630, in h5py.h5t.py_create
  File "h5py\h5t.pyx", line 1652, in h5py.h5t.py_create
  File "h5py\h5t.pyx", line 1707, in h5py.h5t.py_create
TypeError: Object dtype dtype('O') has no native HDF5 equivalent
```
The fix that is proposed here will just set the description annotation to an empty string if the `click.Option.help` property is `None`. Additionally, I create a `h5py.Empty` dataset if a `None` value is encountered as a dictionary value rather than continue in the loop. The caveat on this last point is the empty dataset is created with a dtype of variable length string, as we can't know the data type of the incoming `None` and `h5py.Empty` requires a dtype. I'm open to suggestions on this last point.