### PR TITLE
upgraded joblib

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -10,7 +10,7 @@ setup(
     install_requires=['h5py', 'matplotlib', 'scipy>=0.19',
                       'scikit-image>=0.13', 'scikit-learn==0.19',
                       'tqdm', 'statsmodels>=0.8.0', 'numpy==1.14.5',
-                      'joblib==0.11', 'opencv-python>=4',
+                      'joblib==0.13.1', 'opencv-python>=4',
                       'click', 'ruamel.yaml>=0.15.0'],
     python_requires='>=3.6',
     entry_points={'console_scripts': ['moseq2-extract = moseq2_extract.cli:cli']}


### PR DESCRIPTION
Upgraded joblib, tested loading in moseq models saved with joblib `0.11`. Works without error.