### PR TITLE
ROI Helper Function Refactor

### DIFF
--- a/moseq2_extract/extract/roi.py
+++ b/moseq2_extract/extract/roi.py
@@ -37,20 +37,21 @@ def plane_fit3(points):
     return plane
 
 
-def plane_ransac(depth_image, depth_range=(650, 750), iters=1000,
-                 noise_tolerance=30, in_ratio=.1, progress_bar=False, mask=None):
+def plane_ransac(depth_image, bg_roi_depth_range=(650, 750), iters=1000,
+                 noise_tolerance=30, in_ratio=.1, progress_bar=False, mask=None, **kwargs):
     '''
     Naive RANSAC implementation for plane fitting
 
     Parameters
     ----------
     depth_image (2d numpy array): hxw, background image to fit plane to
-    depth_range (tuple): min/max depth (mm) to consider pixels for plane
+    bg_roi_depth_range (tuple): min/max depth (mm) to consider pixels for plane
     iters (int): number of RANSAC iterations
     noise_tolerance (float): dist. from plane to consider a point an inlier
     in_ratio (float): frac. of points required to consider a plane fit good
     progress_bar (bool): display progress bar
     mask (bool 2d np.array): boolean mask to find region to use
+    kwargs (dict): dictionary containing extra keyword arguments from moseq2_extract.proc.get_roi()
 
     Returns
     -------
@@ -58,7 +59,7 @@ def plane_ransac(depth_image, depth_range=(650, 750), iters=1000,
     dist (1d numpy array): distance of the calculated coordinates and "best plane"
     '''
 
-    use_points = np.logical_and(depth_image > depth_range[0], depth_image < depth_range[1])
+    use_points = np.logical_and(depth_image > bg_roi_depth_range[0], depth_image < bg_roi_depth_range[1])
 
     if mask is not None:
         use_points = np.logical_and(use_points, mask)

--- a/moseq2_extract/helpers/wrappers.py
+++ b/moseq2_extract/helpers/wrappers.py
@@ -208,18 +208,10 @@ def get_roi_wrapper(input_file, config_data, output_dir=None):
     strel_erode = select_strel(config_data['bg_roi_shape'], tuple(config_data['bg_roi_erode']))
 
     rois, plane, _, _, _, _ = get_roi(bground_im,
-                                  strel_dilate=strel_dilate,
-                                  strel_erode=strel_erode,
-                                  dilate_iters=config_data['dilate_iterations'],
-                                  erode_iters=config_data['erode_iterations'],
-                                  noise_tolerance=config_data['noise_tolerance'],
-                                  weights=config_data['bg_roi_weights'],
-                                  depth_range=config_data['bg_roi_depth_range'],
-                                  overlap_roi=config_data.get('overlap_roi'),
-                                  gradient_filter=config_data['bg_roi_gradient_filter'],
-                                  gradient_threshold=config_data['bg_roi_gradient_threshold'],
-                                  gradient_kernel=config_data['bg_roi_gradient_kernel'],
-                                  fill_holes=config_data['bg_roi_fill_holes'])
+                                      **config_data,
+                                      strel_dilate=strel_dilate,
+                                      strel_erode=strel_erode
+                                      )
 
     if config_data['use_plane_bground']:
         print('Using plane fit for background...')

--- a/tests/unit_tests/test_extract_proc.py
+++ b/tests/unit_tests/test_extract_proc.py
@@ -19,7 +19,7 @@ class TestExtractProc(TestCase):
 
             if re.search(r'gradient', bground) is not None:
                 roi = get_roi(tmp.astype('float32'), depth_range=(750, 900),
-                              iters=5000, noise_tolerance=30, gradient_filter=True)
+                              iters=5000, noise_tolerance=30, bg_roi_gradient_filter=True)
             else:
                 roi = get_roi(tmp.astype('float32'), depth_range=(650, 750),
                               iters=5000, noise_tolerance=30)

--- a/tests/unit_tests/test_extract_roi.py
+++ b/tests/unit_tests/test_extract_roi.py
@@ -46,7 +46,7 @@ class TestExtractROI(TestCase):
         z = plane_equation_noisy(xy.T, noise_scale=.1)
         tmp_img = z.reshape(xx.shape)
 
-        a = plane_ransac(tmp_img, depth_range=(0, 1000),
+        a = plane_ransac(tmp_img, bg_roi_depth_range=(0, 1000),
                          iters=1000, noise_tolerance=10)
         norma = -a[0]/a[0][2]
 


### PR DESCRIPTION
Renamed `get_roi()` function parameters to match the CLI options. This is done to simplify the function call, and reuse the CLI parameter inputs throughout the command execution.
***

## Wrapper Changes
- In `get_roi_wrapper()`, changed `get_roi()` function call inputs to unpack `config_data` as in the `extract_wrapper()`.

## `proc.py` Changes
- In `get_roi()`, the following parameter names were changed to match CLI options:
    - `dilate_iters` -> `dilate_iterations`
    - `erode_iters` -> `erode_iterations`
    - `weights` -> `bg_roi_weights`
    - `gradient_filter` -> `bg_roi_gradient_filter`
    - `gradient_kernel` -> `bg_roi_gradient_threshold`
    - `fill_holes` -> `bg_roi_fill_holes`

## `roi.py` Changes
- Changed the input argument `depth_range` -> `bg_roi_depth_range` to match the CLI option.
    - This function is called via `proc.get_roi()` and was previously passed `depth_range` as a `kwarg`. Now that is unnecessary.

## Test Changes
- `test_extract_proc.py` and `test_extract_roi.py` simply had the parameter names changed in the function calls to match the updates above.