### PR TITLE
Background Compute Speed-Bugfix

### DIFF
--- a/moseq2_extract/extract/proc.py
+++ b/moseq2_extract/extract/proc.py
@@ -118,8 +118,12 @@ def get_bground_im_file(frames_file, frame_stride=500, med_scale=5, **kwargs):
 
         frame_idx = np.arange(0, finfo['nframes'], frame_stride)
         frame_store = []
-        for i, frame in enumerate(frame_idx):
-            frs = moseq2_extract.io.video.load_movie_data(frames_file, [int(frame)], frame_size=finfo['dims'], **kwargs).squeeze()
+        for i, frame in tqdm(enumerate(frame_idx), total=len(frame_idx)):
+            frs = moseq2_extract.io.video.load_movie_data(frames_file,
+                                                          [int(frame)],
+                                                          frame_size=finfo['dims'],
+                                                          finfo=finfo,
+                                                          **kwargs).squeeze()
             frame_store.append(cv2.medianBlur(frs, med_scale))
 
         bground = np.nanmedian(frame_store, axis=0)

--- a/moseq2_extract/io/video.py
+++ b/moseq2_extract/io/video.py
@@ -114,7 +114,7 @@ def read_frames_raw(filename, frames=None, frame_size=(512, 424), bit_depth=16, 
 
 
 # https://gist.github.com/hiwonjoon/035a1ead72a767add4b87afe03d0dd7b
-def get_video_info(filename, threads=4):
+def get_video_info(filename, threads=6):
     '''
     Get dimensions of data compressed using ffv1, along with duration via ffmpeg.
 
@@ -514,7 +514,7 @@ def get_movie_info(filename, frame_size=(512, 424), bit_depth=16):
 
     return metadata
 
-def load_mkv_timestamps(input_file):
+def load_mkv_timestamps(input_file, threads=6):
     '''
     Runs a ffprobe command to extract the timestamps from the .mkv file, and pipes the
     output data to a csv file.
@@ -535,6 +535,7 @@ def load_mkv_timestamps(input_file):
         '-show_entries',
         'frame=pkt_pts_time',
         '-v', 'quiet',
+        '-threads', str(threads),
         input_file,
         '-of',
         'csv=p=0'


### PR DESCRIPTION
`finfo` is now being passed to `load_movie_data` in `get_bground_im_file` in order for `read_frames` to not call `get_video_info` each time it is called. 
- This reduces the time taken and overall overhead back to the original time.

Multithreading ffprobe commands for some additional speed up.