### PR TITLE
fix: Removed silent try-except statement from `io.video.write_frames_preview()`

### DIFF
--- a/moseq2_extract/io/video.py
+++ b/moseq2_extract/io/video.py
@@ -466,8 +466,11 @@ def write_frames_preview(filename, frames=np.empty((0,)), threads=6,
         if frame_range is not None:
             try:
                 cv2.putText(disp_img, str(frame_range[i]), txt_pos, font, 1, white, 2, cv2.LINE_AA)
-            except:
-                pass
+            except (IndexError, ValueError):
+                # len(frame_range) M < len(frames) or
+                # txt_pos is outside of the frame dimensions
+                print('Could not overlay frame number on preview on video.')
+
         pipe.stdin.write(disp_img.astype('uint8').tostring())
 
     if close_pipe:


### PR DESCRIPTION
## Issue being fixed or feature implemented
`write_frames_preview` passes silently in `try-except` when attempting to write the frame number of the video.

## How Has This Been Tested?
Locally and Travis

## What Was Done?
Caught the exception type, and printed a message to indicate an error.

## Breaking Changes
None

## Checklists
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated relevant unit/integration/functional/e2e tests
- [ ] I have made corresponding changes to the documentation
