### PR TITLE
fix: bg_roi_dilate in test suite ref doesn't match the actual case

### DIFF
--- a/tests/unit_tests/test_util.py
+++ b/tests/unit_tests/test_util.py
@@ -287,7 +287,7 @@ class TestExtractUtils(TestCase):
 
     def test_click_param_annot(self):
         ref_dict = {
-            'bg_roi_dilate': 'Size of strel to dilate roi',
+            'bg_roi_dilate': 'Size of StructuringElement to dilate roi',
             'bg_roi_shape': 'Shape to use to dilate roi (ellipse or rect)',
             'bg_roi_index': 'Index of which background mask(s) to use',
             'bg_roi_weights': 'ROI feature weighting (area, extent, dist)',


### PR DESCRIPTION
## Issue being fixed or feature implemented
CI and pytest fail because the help value of `--bg-roi-dilate` in `common_roi_options` doesn't match the reference in `test_click_param_annot` in `test_util.py`. 

help value of `--bg-roi-dilate` in `common_roi_options` was changed in https://github.com/dattalab/moseq2-extract/pull/130 but the related test was not changed.

## What was done?
Change the ref dictionary in `test_click_param_annot` in `test_util.py` to match the updated help message.



## How Has This Been Tested?
Locally and CI


## Breaking Changes
NA

## Checklist:
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have added or updated relevant unit/integration/functional/e2e tests
- [ ] I have made corresponding changes to the documentation



