### PR TITLE
fix: CLI download flip file's default is not current working directory

### DIFF
--- a/moseq2_extract/cli.py
+++ b/moseq2_extract/cli.py
@@ -203,7 +203,7 @@ def batch_extract(input_folder, output_dir, skip_completed, num_frames, extensio
 @cli.command(name="download-flip-file", help="Downloads Flip-correction model that helps with orienting the mouse during extraction.")
 @click.argument('config-file', type=click.Path(exists=True, resolve_path=False), default='config.yaml')
 @click.option('--output-dir', type=click.Path(),
-              default=os.path.expanduser('~/moseq2'), help="Temp storage")
+              default=os.getcwd(), help="Output directory for downloaded flip flie")
 def download_flip_file(config_file, output_dir):
 
     flip_file_wrapper(config_file, output_dir)


### PR DESCRIPTION
## Issue being fixed or feature implemented
`moseq2-extract` CLI `download-flip-file` is not set to the current working directory, and users may not be able to find the downloaded flip file. 

## What was done?
In moseq2_extract/cli.py, I changed the default to the current working directory.

## How Has This Been Tested?
Locally and CI. All passed.

## Breaking Changes
None


## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated relevant unit/integration/functional/e2e tests
- [ ] I have made corresponding changes to the documentation
