### PR TITLE
feat: enabling using frames as timestamp for avi

### DIFF
--- a/LICNESE.md
+++ b/LICNESE.md
@@ -1,0 +1,47 @@
+# Academic and Non-Commercial Research Use Software License and Terms of Use
+
+MoSeq is a software package that includes original code created by the Harvard researchers listed below (the “Software”), and third-party code that may be obtained by End Users under separate terms of use. The Software is designed to label behaviors identified from 3D pose dynamics data through the use of computational modeling and fitting approaches. The Software was developed by Alexander Wiltschko, Ph.D., Sandeep Robert Datta, Ph.D., and Matthew J. Johnson, Ph.D. at Harvard University. It is distributed for free academic and non-commercial research use by President and Fellows of Harvard College (“Harvard”).
+
+Using the Software indicates your agreement to be bound by the terms of this Academic and Non-Commercial Research Use Software License and Terms of Use (“License and Terms of Use”). Absent your agreement to the terms below, you (the “End User”) have no rights to hold or use the Software whatsoever.
+
+Harvard agrees to grant hereunder a limited non-exclusive license to End User for the use of the Software in the performance of End User’s internal, non-commercial research on the following terms and conditions:
+
+1. **NO REDISTRIBUTION.** The Software remains the property of Harvard, and End User shall not publish, distribute, or otherwise transfer or make available the Software to any other party.
+
+2. **NO COMMERCIAL USE.** End User shall not use the Software for Commercial use and any such use of the Software is expressly prohibited. “Commercial use” includes, but is not limited to, (i) use of the Software in fee-for-service arrangements, (ii) use of the Software by core facilities or laboratories at non-profit institutions to provide research services to (or in collaboration with) for-profit third parties for a fee, (iii) use of the Software in industry-sponsored and/or collaborative research projects in which any rights to use the Software are granted to the industry sponsor or collaborator, and (iv) use of the Software by a for-profit entity in internal research conducted for the purpose of testing, improving or screening products or services to be marketed or sold by or on behalf of such entity. If End User wishes to use the Software for Commercial use, End User must execute a separate license agreement with Harvard.
+
+
+Requests for use of the Software for Commercial use, please contact:
+
+Office of Technology Development
+Harvard University
+Smith Campus Center, Suite 727E
+1350 Massachusetts Avenue Cambridge, MA 02138 USA Telephone: (617) 495-3067
+E-mail: otd@harvard.edu
+
+3. **OWNERSHIP AND COPYRIGHT NOTICE.** Harvard owns all intellectual property in the Software. End User shall gain no ownership to the Software. End User shall not remove or delete, and shall retain in the Software (including in any modifications to the Software and in any Derivative Works), the copyright, trademark, or other notices pertaining to Software as provided with the Software.
+
+4. **DERIVATIVE WORKS; IMPROVEMENTS; MODIFICATIONS.** End User may improve, modify and create and use Derivative Works (as such term is defined under U.S. copyright laws) of the Software, , provided however, that the use of any such improvements, modifications or Derivative Works shall be restricted to non-commercial, internal research by End User. End User may not distribute such improvements, modifications or Derivative Works to any third parties or use such improvements, modifications or Derivative Works of the Software for any Commercial use.
+
+5. **FEEDBACK.** In order to improve the Software, comments from End Users may be useful. End User agrees to provide Harvard with feedback on the End User’s use of the Software (e.g., any bugs in the Software, the user experience, etc.). Harvard is permitted to use such information provided by End User in making changes and improvements to the Software without compensation or accounting to End User.
+
+6. **NON ASSERT.** End User acknowledges that Harvard may develop modifications to the Software that may be based on the feedback provided by End User under Section 5 above. Harvard shall not be restricted in any way by End User regarding its use of such information. End User acknowledges the right of Harvard to prepare, publish, display, reproduce, transmit and or use modifications to the Software that may be substantially similar or functionally equivalent to End User’s modifications and/or improvements if any. In the event that End User obtains patent protection for any modification or improvement to Software, End User agrees not to allege or enjoin infringement of End User’s patent against Harvard, or any of the researchers, medical or research staff, officers, directors and employees of those institutions.
+
+7. **PUBLICATION & ATTRIBUTION.** End User has the right to publish, present, or share results from the use of the Software. In accordance with customary academic practice, End User will acknowledge Harvard as the provider of the Software and may cite the relevant reference(s) from the following list of publications:
+
+Wiltschko AB, Johnson MJ, Iurilli G, Peterson RE, Katon JE, Pashkovski SL, Abraira VE, Adams RP and Datta SR. (2015). Mapping sub-second Structure in Behavior. Neuron, 88:1121.
+
+Markowitz JE, Gillis WF, Beron CC, Neufeld SQ, Robertson K, Bhagat ND, Peterson RE, Peterson E, Hyun M, Linderman SW, Sabatini BL and Datta SR. (2018). The striatum organizes 3D behavior via moment-to-moment action selection. Cell, in press.
+
+8. **NO WARRANTIES.** THE SOFTWARE IS PROVIDED "AS IS." TO THE FULLEST EXTENT PERMITTED BY LAW, HARVARD HEREBY DISCLAIMS ALL WARRANTIES OF ANY KIND (EXPRESS, IMPLIED OR OTHERWISE) REGARDING THE SOFTWARE, INCLUDING BUT NOT LIMITED TO ANY IMPLIED WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE, OWNERSHIP, AND NON-INFRINGEMENT. HARVARD MAKES NO WARRANTY ABOUT THE ACCURACY, RELIABILITY, COMPLETENESS, TIMELINESS, SUFFICIENCY OR QUALITY OF THE SOFTWARE. HARVARD DOES NOT WARRANT THAT THE SOFTWARE WILL OPERATE WITHOUT ERROR OR INTERRUPTION.
+
+
+9. **LIMITATIONS OF LIABILITY AND REMEDIES.** USE OF THE SOFTWARE IS AT END USER’S OWN RISK. IF END USER IS DISSATISFIED WITH THE SOFTWARE, ITS EXCLUSIVE REMEDY IS TO STOP USING IT. IN NO EVENT SHALL HARVARD BE LIABLE TO END USER, IN CONTRACT, TORT OR OTHERWISE, FOR ANY DIRECT, INDIRECT, SPECIAL, INCIDENTAL, CONSEQUENTIAL, PUNITIVE OR OTHER DAMAGES OF ANY KIND WHATSOEVER ARISING OUT OF OR IN CONNECTION WITH THE SOFTWARE, EVEN IF HARVARD IS NEGLIGENT OR OTHERWISE AT FAULT, AND REGARDLESS OF WHETHER HARVARD IS ADVISED OF THE POSSIBILITY OF SUCH DAMAGES.
+
+10. **INDEMNIFICATION.** To the extent permitted by law, End User shall indemnify, defend and hold harmless Harvard, its current and former corporate affiliates, directors, trustees, officers, faculty, medical and professional staff, employees, students and agents and their respective successors, heirs and assigns (the "Indemnitees"), against any liability, damage, loss or expense (including reasonable attorney's fees and expenses of litigation) incurred by or imposed upon the Indemnitees or any one of them in connection with any claims, suits, actions, demands or judgments arising from End User’s breach of this License and Terms of Use or End User’s use of the Software. This indemnification provision shall survive expiration or termination of this License and Terms of Use.
+
+11. **GOVERNING LAW.** This License and Terms of Use shall be construed and governed by the laws of the Commonwealth of Massachusetts regardless of otherwise applicable choice of law standards.
+
+12. **NON-USE OF NAME.** Nothing in this License and Terms of Use shall be construed as granting End User any rights or licenses to use any trademarks, service marks or logos associated with the Software. End User may not use the terms “Harvard” (or a substantially similar term) in any way that is inconsistent with the permitted uses described herein. End User may not use any name or emblem of Harvard or any of its schools or subdivisions for any purpose, or to falsely suggest any relationship between End User and Harvard, or in any manner that would infringe or violate any of its rights.
+
+

--- a/moseq2_extract/cli.py
+++ b/moseq2_extract/cli.py
@@ -279,17 +279,19 @@ def aggregate_extract_results(input_dir, format, output_dir, mouse_threshold):
 @cli.command(name="convert-raw-to-avi", help='Converts/Compresses a raw depth file into an avi file (with depth values) that is 8x smaller.')
 @click.argument('input-file', type=click.Path(exists=True, resolve_path=False))
 @common_avi_options
-def convert_raw_to_avi(input_file, output_file, chunk_size, fps, delete, threads, mapping):
+@click.option('--frames-is-timestamp', is_flag=True, default = False, help='Use frames as timestamp')
+def convert_raw_to_avi(input_file, output_file, chunk_size, fps, delete, frames_is_timestamp, threads, mapping):
 
-    convert_raw_to_avi_wrapper(input_file, output_file, chunk_size, fps, delete, threads, mapping)
+    convert_raw_to_avi_wrapper(input_file, output_file, chunk_size, fps, delete, frames_is_timestamp, threads, mapping)
 
 @cli.command(name="copy-slice", help='Copies a segment of an input depth recording into a new video file.')
 @click.argument('input-file', type=click.Path(exists=True, resolve_path=False))
 @common_avi_options
 @click.option('-c', '--copy-slice', type=(int, int), default=(0, 1000), help='Slice indices used for copy')
-def copy_slice(input_file, output_file, copy_slice, chunk_size, fps, delete, threads, mapping):
+@click.option('--frames-is-timestamp', is_flag=True, default = False, help='Use frames as timestamp')
+def copy_slice(input_file, output_file, copy_slice, chunk_size, fps, delete, frames_is_timestamp, threads, mapping):
 
-    copy_slice_wrapper(input_file, output_file, copy_slice, chunk_size, fps, delete, threads, mapping)
+    copy_slice_wrapper(input_file, output_file, copy_slice, chunk_size, fps, delete, frames_is_timestamp, threads, mapping)
 
 if __name__ == '__main__':
     cli()

--- a/moseq2_extract/cli.py
+++ b/moseq2_extract/cli.py
@@ -85,6 +85,8 @@ def common_roi_options(function):
     function = click.option('--output-dir', default='proc', help='Output directory to save the results h5 file')(function)
     function = click.option('--use-plane-bground', is_flag=True,
                             help='Use a plane fit for the background. Useful for mice that don\'t move much')(function)
+    function = click.option('--frames-is-timestamp', is_flag=True,
+                            help='Use frames as timestamp')(function)
     function = click.option('--recompute-bg', default=False, help='Overwrite previously computed background image')(
         function)
     function = click.option("--config-file", type=click.Path())(function)

--- a/moseq2_extract/helpers/wrappers.py
+++ b/moseq2_extract/helpers/wrappers.py
@@ -464,7 +464,7 @@ def flip_file_wrapper(config_file, output_dir, selected_flip=None):
         print('Could not update configuration file flip classifier path')
         print('Unexpected error:', e)
 
-def convert_raw_to_avi_wrapper(input_file, output_file, chunk_size, fps, delete, threads, mapping):
+def convert_raw_to_avi_wrapper(input_file, output_file, chunk_size, fps, delete, frames_is_timestamp, threads, mapping):
     '''
     Wrapper function used to convert/compress a raw depth file into
      an avi file (with depth values) that is 8x smaller.
@@ -492,7 +492,7 @@ def convert_raw_to_avi_wrapper(input_file, output_file, chunk_size, fps, delete,
     video_pipe = None
 
     for batch in tqdm(frame_batches, desc='Encoding batches'):
-        frames = load_movie_data(input_file, batch, mapping=mapping)
+        frames = load_movie_data(input_file, batch, mapping=mapping, frames_is_timestamp = frames_is_timestamp)
         video_pipe = write_frames(output_file, frames, pipe=video_pipe,
                                   close_pipe=False, threads=threads, fps=fps)
 
@@ -500,8 +500,8 @@ def convert_raw_to_avi_wrapper(input_file, output_file, chunk_size, fps, delete,
         video_pipe.communicate()
 
     for batch in tqdm(frame_batches, desc='Checking data integrity'):
-        raw_frames = load_movie_data(input_file, batch, mapping=mapping)
-        encoded_frames = load_movie_data(output_file, batch, mapping=mapping)
+        raw_frames = load_movie_data(input_file, batch, mapping=mapping, frames_is_timestamp = frames_is_timestamp)
+        encoded_frames = load_movie_data(output_file, batch, mapping=mapping, frames_is_timestamp = frames_is_timestamp)
 
         if not np.array_equal(raw_frames, encoded_frames):
             raise RuntimeError(f'Raw frames and encoded frames not equal from {batch[0]} to {batch[-1]}')
@@ -512,7 +512,7 @@ def convert_raw_to_avi_wrapper(input_file, output_file, chunk_size, fps, delete,
         print('Deleting', input_file)
         os.remove(input_file)
 
-def copy_slice_wrapper(input_file, output_file, copy_slice, chunk_size, fps, delete, threads, mapping):
+def copy_slice_wrapper(input_file, output_file, copy_slice, chunk_size, fps, delete, frames_is_timestamp, threads, mapping):
     '''
     Wrapper function to copy a segment of an input depth recording into a new video file.
 
@@ -556,7 +556,7 @@ def copy_slice_wrapper(input_file, output_file, copy_slice, chunk_size, fps, del
             sys.exit(0)
 
     for batch in tqdm(frame_batches, desc='Encoding batches'):
-        frames = load_movie_data(input_file, batch, mapping=mapping)
+        frames = load_movie_data(input_file, batch, mapping=mapping, frames_is_timestamp=frames_is_timestamp)
         if avi_encode:
             video_pipe = write_frames(output_file,
                                       frames,
@@ -572,8 +572,8 @@ def copy_slice_wrapper(input_file, output_file, copy_slice, chunk_size, fps, del
         video_pipe.communicate()
 
     for batch in tqdm(frame_batches, desc='Checking data integrity'):
-        raw_frames = load_movie_data(input_file, batch, mapping=mapping)
-        encoded_frames = load_movie_data(output_file, batch, mapping=mapping)
+        raw_frames = load_movie_data(input_file, batch, mapping=mapping, frames_is_timestamp=frames_is_timestamp)
+        encoded_frames = load_movie_data(output_file, batch, mapping=mapping, frames_is_timestamp=frames_is_timestamp)
 
         if not np.array_equal(raw_frames, encoded_frames):
             raise RuntimeError(f'Raw frames and encoded frames not equal from {batch[0]} to {batch[-1]}')

--- a/moseq2_extract/io/video.py
+++ b/moseq2_extract/io/video.py
@@ -279,7 +279,7 @@ def read_frames(filename, frames=range(0,), threads=6, fps=30, frames_is_timesta
     fps (int): frame rate of camera in Hz
     frames_is_timestamp (bool): if False, indicates timestamps represent kinect v2 absolute machine timestamps,
      if True, indicates azure relative start_time timestamps (i.e. first frame timestamp == 0.000).
-    pixel_format (str): ffmpeg pixel format of data
+    pixel_format (str): ffmpeg pixel format of da
     movie_dtype (str): An indicator for numpy to store the piped ffmpeg-read video in memory for processing.
     frame_size (str): wxh frame size in pixels
     slices (int): number of slices to use for decode
@@ -377,9 +377,11 @@ def read_mkv(filename, frames=range(0,), pixel_format='gray16be', movie_dtype='u
     video (3d numpy array):  frames x h x w
     '''
 
+    # extract timestamp from mkv if the timestamps is not provided
     if timestamps is None and exists(filename):
         timestamps = load_timestamps_from_movie(filename, mapping=kwargs.get('mapping', 'DEPTH'))
 
+    # slice the timestamp into frames
     if timestamps is not None:
         if isinstance(frames, range):
             frames = timestamps[slice(frames.start, frames.stop, frames.step)]

--- a/tests/unit_tests/test_util.py
+++ b/tests/unit_tests/test_util.py
@@ -307,11 +307,13 @@ class TestExtractUtils(TestCase):
             'noise_tolerance': 'Extent of noise to accept during RANSAC Plane ROI computation. (Special Cases Only)',
             'output_dir': 'Output directory to save the results h5 file',
             'use_plane_bground': 'Use a plane fit for the background. Useful for mice that don\'t move much',
+            'frames_is_timestamp': 'Use frames as timestamp',
             'recompute_bg': 'Overwrite previously computed background image',
             'config_file': None,
             'progress_bar': 'Show verbose progress bars.'
         }
         test_dict = click_param_annot(find_roi)
+        print(test_dict)
         npt.assert_equal(ref_dict, test_dict)
 
     def test_command_with_config(self):


### PR DESCRIPTION
## Issue being fixed or feature implemented
issue described here https://github.com/dattalab/moseq2-extract/issues/142


## What was done?
I added `frames-is-timestamp` flag to the CLI.


## How Has This Been Tested?
CI and locally.


## Breaking Changes
Now frames_is-timestamp is a param for `convert_raw_to_avi_wrapper` and `copy_slice_wrapper` but no output breaking changes.

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have added or updated relevant unit/integration/functional/e2e tests
- [ ] I have made corresponding changes to the documentation
