### PR TITLE
feat: ensure true_depth is added to result_00.yaml

### DIFF
--- a/moseq2_extract/helpers/wrappers.py
+++ b/moseq2_extract/helpers/wrappers.py
@@ -397,8 +397,8 @@ def extract_wrapper(input_file, output_dir, config_data, num_frames=None, skip=F
 
     status_dict['complete'] = True
     if status_dict['parameters'].get('true_depth') is None:
-        status_dict['parameters']['true_depth'] = config_data.get('true_depth')
-
+        # config_data.get('true_depth') is numpy.float64 and yaml.safe_dump can't represent the object
+        status_dict['parameters']['true_depth'] = float(config_data.get('true_depth'))
     with open(status_filename, 'w') as f:
         yaml.safe_dump(status_dict, f)
 


### PR DESCRIPTION
## Issue being fixed or feature implemented
result_00.yaml won't record `true_depth` if` detected_truth_depth` is not in `config_data`.


## What was done?
I added the addition `true_depth` to `status_dict` to record the true_depth.


## How Has This Been Tested?
locally and CI


## Breaking Changes
NA


## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added or updated relevant unit/integration/functional/e2e tests
- [ ] I have made corresponding changes to the documentation
