### PR TITLE
fix: movie_dtype should actually be set to <u2

### DIFF
--- a/moseq2_extract/io/video.py
+++ b/moseq2_extract/io/video.py
@@ -50,7 +50,7 @@ def get_raw_info(filename, bit_depth=16, frame_size=(512, 424)):
     return file_info
 
 
-def read_frames_raw(filename, frames=None, frame_size=(512, 424), bit_depth=16, movie_dtype="<i2", **kwargs):
+def read_frames_raw(filename, frames=None, frame_size=(512, 424), bit_depth=16, movie_dtype="<u2", **kwargs):
     '''
     Reads in data from raw binary file.
 


### PR DESCRIPTION
## Issue being fixed or feature implemented
https://github.com/dattalab/moseq2-extract/issues/147

## What was done?
movie_dtype set to <u2

## How Has This Been Tested?
tested running with `moseq2-extract convert-raw-to-avi`

## Breaking Changes
<!--- Please describe any breaking changes your code introduces and verify that -->
<!--- the title includes "!" following the conventional commit type (e.g. "feat!: ..."-->


## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated relevant unit/integration/functional/e2e tests
- [ ] I have made corresponding changes to the documentation
