### PR TITLE
fix: apply flip classifier on filtered frames

### DIFF
--- a/moseq2_extract/extract/extract.py
+++ b/moseq2_extract/extract/extract.py
@@ -169,7 +169,7 @@ def extract_chunk(chunk, use_tracking_model=False, spatial_filter_size=(3,),
     # Orient mouse to face east
     if flip_classifier:
         # get frame indices of incorrectly orientation
-        flips = get_flips(cropped_frames, flip_classifier, flip_classifier_smoothing)
+        flips = get_flips(cropped_filtered_frames, flip_classifier, flip_classifier_smoothing)
         flip_indices = np.where(flips)
 
         # apply flips


### PR DESCRIPTION
## Issue being fixed or feature implemented
flip classifier not applied to the cleaned frames but the flip classifiers are trained on cleaned frames


## What was done?
applying flip classifier on cleaned frames


## How Has This Been Tested?
locally


## Breaking Changes
NA

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated relevant unit/integration/functional/e2e tests
- [ ] I have made corresponding changes to the documentation
