### PR TITLE
fix: pass in frame size detected from finfo

### DIFF
--- a/moseq2_extract/helpers/wrappers.py
+++ b/moseq2_extract/helpers/wrappers.py
@@ -164,6 +164,7 @@ def get_roi_wrapper(input_file, config_data, output_dir=None):
     config_data['output_dir'] = output_dir
 
     if config_data.get('finfo') is None:
+        # when depth video is .avi, frame_size/dim is read directly from the video
         config_data['finfo'] = get_movie_info(input_file, **config_data)
 
     # checks camera type to set appropriate bg_roi_weights
@@ -185,7 +186,8 @@ def get_roi_wrapper(input_file, config_data, output_dir=None):
         adjusted_bg_depth_range = bground_im[cY][cX]
         config_data['bg_roi_depth_range'] = [int(adjusted_bg_depth_range-50), int(adjusted_bg_depth_range+50)]
 
-    first_frame = load_movie_data(input_file, 0, **config_data) # there is a tar object flag that must be set!!
+    # pass in config_data['finfo']['dims'] for frame size otherwise frame size is hard coded to 512x424
+    first_frame = load_movie_data(input_file, 0, frame_size=config_data['finfo']['dims'], **config_data) # there is a tar object flag that must be set!!
     write_image(join(output_dir, 'first_frame.tiff'), first_frame, scale=True,
                 scale_factor=config_data['bg_roi_depth_range'])
 


### PR DESCRIPTION
## Issue being fixed or feature implemented
frame size for finding first frame is hard coded to 512x424 - if the resolution of the input video is different, first frame won't be correct


## What was done?
pass in the frame size from finfo as an input


## How Has This Been Tested?
Locally


## Breaking Changes
<!--- Please describe any breaking changes your code introduces and verify that -->
<!--- the title includes "!" following the conventional commit type (e.g. "feat!: ..."-->


## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated relevant unit/integration/functional/e2e tests
- [ ] I have made corresponding changes to the documentation
