### PR TITLE
fix: ignore IR files when searching for recordings

### DIFF
--- a/moseq2_extract/util.py
+++ b/moseq2_extract/util.py
@@ -893,7 +893,7 @@ def recursive_find_unextracted_dirs(root_dir=os.getcwd(),
     proc_dirs = []
     for root, _, files in os.walk(root_dir):
         for file in files:
-            if file.endswith(extension):  # test for uncompressed session
+            if file.endswith(extension) and not file.startswith("ir"):  # test for uncompressed session
                 status_file = join(root, yaml_path)
                 metadata_file = join(root, metadata_path)
             elif session_archive_pattern.fullmatch(file):  # test for compressed session


### PR DESCRIPTION
Modified the `recursive_find_unextracted_dirs` function so that it ignores IR files saved as either `ir.dat` or `ir.avi` when looking for unextracted moseq folders.

<!--- Provide a general summary of your changes in the Title above -->
<!--- Pull request titles must use the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) format -->

## Issue being fixed or feature implemented
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->


## What was done?
<!--- Describe your changes in detail -->


## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->


## Breaking Changes
<!--- Please describe any breaking changes your code introduces and verify that -->
<!--- the title includes "!" following the conventional commit type (e.g. "feat!: ..."-->


## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated relevant unit/integration/functional/e2e tests
- [ ] I have made corresponding changes to the documentation
