### PR TITLE
TEST ONLY: external-fork MoSeq2 CI proof

### DIFF
--- a/.github/workflows/moseq2-test.yml
+++ b/.github/workflows/moseq2-test.yml
@@ -20,7 +20,7 @@ jobs:
           fetch-depth: 0
           persist-credentials: false
       - name: Build the candidate wheel and run its affected MoSeq2 tests
-        uses: dattalab/moseq2-test@0748bdd9d47a07ed053a1d9f4a9dd4f9187bdbf1
+        uses: dattalab/moseq2-test@f900aafc9c3b39d1c996528d1413e835b54bb9a2
         with:
           package: moseq2-extract
           source: ${{ github.workspace }}

--- a/.github/workflows/moseq2-test.yml
+++ b/.github/workflows/moseq2-test.yml
@@ -20,7 +20,7 @@ jobs:
           fetch-depth: 0
           persist-credentials: false
       - name: Build the candidate wheel and run its affected MoSeq2 tests
-        uses: dattalab/moseq2-test@559b0eb4ae94a4ddb57aafacd98464b6168b8828
+        uses: dattalab/moseq2-test@0748bdd9d47a07ed053a1d9f4a9dd4f9187bdbf1
         with:
           package: moseq2-extract
           source: ${{ github.workspace }}

--- a/.github/workflows/moseq2-test.yml
+++ b/.github/workflows/moseq2-test.yml
@@ -20,7 +20,7 @@ jobs:
           fetch-depth: 0
           persist-credentials: false
       - name: Build the candidate wheel and run its affected MoSeq2 tests
-        uses: dattalab/moseq2-test@b23eb6c2cb84f4d37868b24abc8fb2b02f9d3ebe
+        uses: dattalab/moseq2-test@eb652cd8058a2fe34f7ea3c2d638aa7f6f2ebb47
         with:
           package: moseq2-extract
           source: ${{ github.workspace }}

--- a/.github/workflows/moseq2-test.yml
+++ b/.github/workflows/moseq2-test.yml
@@ -20,7 +20,7 @@ jobs:
           fetch-depth: 0
           persist-credentials: false
       - name: Build the candidate wheel and run its affected MoSeq2 tests
-        uses: dattalab/moseq2-test@eb652cd8058a2fe34f7ea3c2d638aa7f6f2ebb47
+        uses: dattalab/moseq2-test@9e696dbbc3e36169366ec309656b87183524ff3d
         with:
           package: moseq2-extract
           source: ${{ github.workspace }}

--- a/.github/workflows/moseq2-test.yml
+++ b/.github/workflows/moseq2-test.yml
@@ -1,0 +1,27 @@
+name: MoSeq2 installed-package tests
+
+on:
+  pull_request:
+  push:
+    branches: [release]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  moseq2-test:
+    runs-on: ubuntu-24.04
+    timeout-minutes: 30
+    steps:
+      - name: Check out the pull-request source
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          fetch-depth: 0
+          persist-credentials: false
+      - name: Build the candidate wheel and run its affected MoSeq2 tests
+        uses: dattalab/moseq2-test@559b0eb4ae94a4ddb57aafacd98464b6168b8828
+        with:
+          package: moseq2-extract
+          source: ${{ github.workspace }}
+          tier: pull-request

--- a/.github/workflows/moseq2-test.yml
+++ b/.github/workflows/moseq2-test.yml
@@ -20,7 +20,7 @@ jobs:
           fetch-depth: 0
           persist-credentials: false
       - name: Build the candidate wheel and run its affected MoSeq2 tests
-        uses: dattalab/moseq2-test@81ec25d1edfc891ac57dfe4246e1e505bf2b29dd
+        uses: dattalab/moseq2-test@b0ec5bdcdc9b57d0c0dacfccc5797760befce587
         with:
           package: moseq2-extract
           source: ${{ github.workspace }}

--- a/.github/workflows/moseq2-test.yml
+++ b/.github/workflows/moseq2-test.yml
@@ -20,7 +20,7 @@ jobs:
           fetch-depth: 0
           persist-credentials: false
       - name: Build the candidate wheel and run its affected MoSeq2 tests
-        uses: dattalab/moseq2-test@a957b2dc060707b223865ce58668e35f58909a4f
+        uses: dattalab/moseq2-test@42a43e7a46ff9c9208e230f61f1e1b2964436e41
         with:
           package: moseq2-extract
           source: ${{ github.workspace }}

--- a/.github/workflows/moseq2-test.yml
+++ b/.github/workflows/moseq2-test.yml
@@ -20,7 +20,7 @@ jobs:
           fetch-depth: 0
           persist-credentials: false
       - name: Build the candidate wheel and run its affected MoSeq2 tests
-        uses: dattalab/moseq2-test@42a43e7a46ff9c9208e230f61f1e1b2964436e41
+        uses: dattalab/moseq2-test@b23eb6c2cb84f4d37868b24abc8fb2b02f9d3ebe
         with:
           package: moseq2-extract
           source: ${{ github.workspace }}

--- a/.github/workflows/moseq2-test.yml
+++ b/.github/workflows/moseq2-test.yml
@@ -20,7 +20,7 @@ jobs:
           fetch-depth: 0
           persist-credentials: false
       - name: Build the candidate wheel and run its affected MoSeq2 tests
-        uses: dattalab/moseq2-test@b0ec5bdcdc9b57d0c0dacfccc5797760befce587
+        uses: dattalab/moseq2-test@a957b2dc060707b223865ce58668e35f58909a4f
         with:
           package: moseq2-extract
           source: ${{ github.workspace }}

--- a/.github/workflows/moseq2-test.yml
+++ b/.github/workflows/moseq2-test.yml
@@ -20,7 +20,7 @@ jobs:
           fetch-depth: 0
           persist-credentials: false
       - name: Build the candidate wheel and run its affected MoSeq2 tests
-        uses: dattalab/moseq2-test@f900aafc9c3b39d1c996528d1413e835b54bb9a2
+        uses: dattalab/moseq2-test@81ec25d1edfc891ac57dfe4246e1e505bf2b29dd
         with:
           package: moseq2-extract
           source: ${{ github.workspace }}


### PR DESCRIPTION
Temporary external-fork security and accessibility proof for Chunk 1.

This branch contains the same workflow-only commit as dattalab/moseq2-extract#176, pinned to moseq2-test commit b23eb6c2cb84f4d37868b24abc8fb2b02f9d3ebe. The purpose is to prove the public pull-request path succeeds from a fork without repository secrets, O2 access, package-write permission, or a self-hosted runner.

After the successful workflow artifact and permissions evidence are retained, this proof PR will be closed without merge and its fork branch deleted.